### PR TITLE
Fix sample/instrument panning bugs

### DIFF
--- a/libntxm/arm9/source/xm_transport.cpp
+++ b/libntxm/arm9/source/xm_transport.cpp
@@ -1133,7 +1133,7 @@ u16 XMTransport::save(const char *filename, Song *song)
 				fwrite(&smp_type, 1, 1, xmfile);
 
 				// Panning
-				u8 smp_panning = sample->getPanning();
+				u8 smp_panning = sample->getBasePanning();
 				fwrite(&smp_panning, 1, 1, xmfile);
 
 				// Relative note

--- a/libntxm/common/source/instrument.cpp
+++ b/libntxm/common/source/instrument.cpp
@@ -46,7 +46,7 @@
 Instrument::Instrument(const char *_name, u8 _type, u8 _volume)
 	:type(_type), volume(_volume),
 	 n_vol_points(0), vol_env_on(false), vol_env_sustain(false), vol_env_loop(false),
-	 n_pan_points(0)
+	 n_pan_points(0), pan_env_on(false), pan_env_sustain(false), pan_env_loop(false)
 {
 	name = (char*)calloc(MAX_INST_NAME_LENGTH+1, 1);
 	
@@ -59,7 +59,9 @@ Instrument::Instrument(const char *_name, u8 _type, u8 _volume)
 }
 
 Instrument::Instrument(const char *_name, Sample *_sample, u8 _volume)
-	:type(INST_SAMPLE), volume(_volume)
+	:type(INST_SAMPLE), volume(_volume),
+	 n_vol_points(0), vol_env_on(false), vol_env_sustain(false), vol_env_loop(false),
+	 n_pan_points(0), pan_env_on(false), pan_env_sustain(false), pan_env_loop(false)
 {
 	name = (char*)malloc(MAX_INST_NAME_LENGTH+1);
 	for(u16 i=0; i<MAX_INST_NAME_LENGTH+1; ++i) name[i] = '\0';

--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -100,7 +100,7 @@ inline u32 linear_freq_table_lookup(u32 note)
 Sample::Sample(void *_sound_data, u32 _n_samples, u16 _sampling_frequency, bool _is_16_bit,
 	u8 _loop, u8 _volume)
 	:original_data(0), pingpong_data(0), n_samples(_n_samples), is_16_bit(_is_16_bit), loop(_loop),
-	loop_start(0), loop_length(0), volume(_volume), panning(64), base_panning(64)
+	loop_start(0), loop_length(0), volume(_volume), panning(128), base_panning(128)
 {
 	sound_data = _sound_data;
 
@@ -114,7 +114,8 @@ Sample::Sample(void *_sound_data, u32 _n_samples, u16 _sampling_frequency, bool 
 }
 
 Sample::Sample(const char *filename, u8 _loop, bool *_success)
-	:original_data(0), pingpong_data(0), loop(_loop), loop_start(0), loop_length(0), volume(255), panning(128)
+	:original_data(0), pingpong_data(0), loop(_loop), loop_start(0), loop_length(0), volume(255),
+	panning(128), base_panning(128)
 {
 	sound_data = (void**)calloc(20*sizeof(void*), 1);
 


### PR DESCRIPTION
This PR fixes some uninitialised and wrongly-initialised fields which would cause instrument panning envelopes to be randomly enabled, as well as sample panning settings to be set wrongly.

Samples seem to have an internal `panning` value which can change due to effect commands, as well as a `base_panning` value which should remain as whatever the user set.

This setup seems strange, I'd expect on-the-fly panning values to belong in channels rather than samples, but maybe there's a reason for it?

I've made it so the `base_panning` is used when saving the sample, since that seems to be the intent.