### PR TITLE
Implement position jump and pattern delay commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .svn/
+build/
+build-debug/
+*.a
+

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -527,6 +527,7 @@ void Player::handleEffects(void)
 {
 	effstate.pattern_loop_jump_now = false;
 	effstate.pattern_break_requested = false;
+	effstate.position_jump_requested = false;
 
 	for(u8 channel=0; channel < song->n_channels && channel<MAX_CHANNELS; ++channel)
 	{
@@ -591,8 +592,9 @@ void Player::handleEffects(void)
 				case EFFECT_POSITION_JUMP:
 				{
 					effstate.pattern_break_requested = true;
+					effstate.position_jump_requested = true;
 					effstate.pattern_break_row = 0;
-					state.potpos = param-1;
+					effstate.position_jump_pos = param;
 					break;
 				}
 
@@ -619,7 +621,6 @@ void Player::handleEffects(void)
 
 					effstate.pattern_break_requested = true;
 					effstate.pattern_break_row = newrow;
-
 					break;
 				}
 
@@ -991,7 +992,9 @@ void Player::initEffState(void)
 	memset(effstate.channel_setvol_requested, false, sizeof(effstate.channel_setvol_requested));
 	memset(effstate.channel_last_slidespeed, 0, sizeof(effstate.channel_last_slidespeed));
 	effstate.pattern_break_requested = false;
+	effstate.position_jump_requested = false;
 	effstate.pattern_break_row = 0;
+	effstate.position_jump_pos = 0;
 	effstate.pattern_delay_store = 0;
 	effstate.pattern_delay = 0;
 }
@@ -1107,11 +1110,13 @@ bool Player::calcNextPos(u16 *nextrow, u8 *nextpotpos) // Calculate next row and
 	if(effstate.pattern_break_requested == true)
 	{
 		*nextrow = effstate.pattern_break_row;
+		
+		int next_pos = effstate.position_jump_requested ? effstate.position_jump_pos : state.potpos + 1;
 
-		if(state.potpos < song->getPotLength() - 1)
-				*nextpotpos = state.potpos + 1;
-			else
-				*nextpotpos = song->getRestartPosition();
+		if(next_pos < song->getPotLength())
+			*nextpotpos = next_pos;
+		else
+			*nextpotpos = song->getRestartPosition();
 
 		return false;
 	}

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -588,6 +588,14 @@ void Player::handleEffects(void)
 					break;
 				}
 
+				case EFFECT_POSITION_JUMP:
+				{
+					effstate.pattern_break_requested = true;
+					effstate.pattern_break_row = 0;
+					state.potpos = param-1;
+					break;
+				}
+
 				case EFFECT_SET_VOLUME:
 				{
 					u8 target_volume = MIN(MAX_VOLUME, param * 2);

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -98,6 +98,8 @@ typedef struct {
 	s16 channel_last_slidespeed[MAX_CHANNELS];
 	bool pattern_break_requested;
 	u8 pattern_break_row;
+	u8 pattern_delay_store;
+	u8 pattern_delay;         // 0: inactive, 1..16: (N-1) repetitions remaining
 } EffectState;
 
 class Player {

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -97,7 +97,9 @@ typedef struct {
 	bool channel_setvol_requested[MAX_CHANNELS];
 	s16 channel_last_slidespeed[MAX_CHANNELS];
 	bool pattern_break_requested;
+	bool position_jump_requested;  // implies pattern_break_requested
 	u8 pattern_break_row;
+	u8 position_jump_pos;
 	u8 pattern_delay_store;
 	u8 pattern_delay;         // 0: inactive, 1..16: (N-1) repetitions remaining
 } EffectState;

--- a/libntxm/include/ntxm/song.h
+++ b/libntxm/include/ntxm/song.h
@@ -82,6 +82,8 @@
 #define EFFECT_E_NOTE_CUT				0x0C
 #define EFFECT_E_NOTE_DELAY        0x0D
 
+#define EFFECT_E_PATTERN_DELAY			0x0E
+
 #define EFFECT_SET_SPEED_TEMPO			0x0F
 /*
   0      Appregio

--- a/libntxm/include/ntxm/song.h
+++ b/libntxm/include/ntxm/song.h
@@ -68,6 +68,7 @@
 
 #define EFFECT_SET_PAN    0x8
 #define EFFECT_VOLUME_SLIDE		0xA
+#define EFFECT_POSITION_JUMP	0xB
 #define EFFECT_SET_VOLUME		0xC
 #define EFFECT_PATTERN_BREAK	0xD
 #define EFFECT_E				0xE


### PR DESCRIPTION
This PR adds support for the Bxx (position jump) and EEx (pattern delay) effect commands.

My main point of uncertainty would be the line `state.potpos = param-1;`, as I couldn't see anywhere else that updates `potpos` directly like that (usually it's done via `calcNextPos`), but given a quick test it seems to work fine.

- [mygg/josss/bonefish - turn it up!](https://github.com/asiekierka/nitrotracker/issues/79) plays just fine.

- [Strobe - Armored Machine](https://www.modules.pl/index.php?id=module&mod=5804) floods the console with _unknown arm7 read8_ but otherwise plays fine. (Similar bad reads occur with the commands removed, so I think it's unrelated?)

(needless to say there are other playback inaccuracies present, but the songs are listenable and none relate to this PR as far as I can tell)