### PR TITLE
Extended midi support

### DIFF
--- a/libntxm/arm7/source/fifocommand7.cpp
+++ b/libntxm/arm7/source/fifocommand7.cpp
@@ -94,7 +94,7 @@ static void RecvCommandStopInst(StopInstCommand *c) {
 }
 
 static void RecvCommandStopMidiInst(StopMidiInstCommand *c) {
-    ntxm7->stopChannel(c->channel);
+    ntxm7->stopNote(c->note, c->volume, c->channel, c->inst);
 }
 
 static void RecvCommandPatternLoop(PatternLoopCommand *c) {

--- a/libntxm/arm7/source/fifocommand7.cpp
+++ b/libntxm/arm7/source/fifocommand7.cpp
@@ -93,6 +93,10 @@ static void RecvCommandStopInst(StopInstCommand *c) {
     ntxm7->stopChannel(c->channel);
 }
 
+static void RecvCommandStopMidiInst(StopMidiInstCommand *c) {
+    ntxm7->stopChannel(c->channel);
+}
+
 static void RecvCommandPatternLoop(PatternLoopCommand *c) {
     ntxm7->setPatternLoop(c->state);
 }
@@ -196,6 +200,9 @@ void CommandRecvHandler(int bytes, void *user_data) {
             break;
         case STOP_INST:
             RecvCommandStopInst(&command.stopInst);
+            break;
+        case STOP_MIDI_INST:
+            RecvCommandStopMidiInst(&command.stopMidiInst);
             break;
         case MIC_ON:
             RecvCommandMicOn();

--- a/libntxm/arm7/source/ntxm7.cpp
+++ b/libntxm/arm7/source/ntxm7.cpp
@@ -84,6 +84,10 @@ void NTXM7::playNote(u8 instidx, u8 note, u8 volume, u8 channel)
 	player->playNote(note, volume, channel, instidx);
 }
 
+void NTXM7::stopNote(u8 note, u8 volume, u8 channel, u8 instidx) {
+	player->stopNote(note, volume, channel, instidx);
+}
+
 void NTXM7::playSample(Sample *sample, u8 note, u8 volume, u8 channel)
 {
 	player->playSample(sample, note, volume, channel);

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -234,6 +234,14 @@ void Player::playSample(Sample *sample, u8 note, u8 volume, u8 channel)
 	sample->play(note, volume, channel);
 }
 
+void Player::stopNote(u8 note, u8 volume, u8 channel, u8 instidx) {
+	for (u8 i = 0; i < MAX_CHANNELS; i++) {
+		if(state.channel_note[i] == note && state.channel_instrument[i] == instidx) {
+			stopChannel(i);
+		}
+	}
+}
+
 // Stop playback on a channel
 void Player::stopChannel(u8 channel)
 {

--- a/libntxm/arm9/source/fifocommand9.cpp
+++ b/libntxm/arm9/source/fifocommand9.cpp
@@ -208,11 +208,14 @@ void CommandStopInst(u8 channel)
 void CommandStopMidiInst(u8 inst, u8 note, u8 volume, u8 channel)
 {
     NTXMFifoMessage command;
-    command.commandType = STOP_INST;
+    command.commandType = STOP_MIDI_INST;
 
-    StopInstCommand* c = &command.stopInst;
+    StopMidiInstCommand* c = &command.stopMidiInst;
 
     c->channel = channel;
+    c->note = note;
+    c->volume = volume;
+    c->inst = inst;
 
     fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
 }

--- a/libntxm/arm9/source/fifocommand9.cpp
+++ b/libntxm/arm9/source/fifocommand9.cpp
@@ -205,6 +205,18 @@ void CommandStopInst(u8 channel)
     fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
 }
 
+void CommandStopMidiInst(u8 inst, u8 note, u8 volume, u8 channel)
+{
+    NTXMFifoMessage command;
+    command.commandType = STOP_INST;
+
+    StopInstCommand* c = &command.stopInst;
+
+    c->channel = channel;
+
+    fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
+}
+
 void CommandMicOn(void)
 {
     NTXMFifoMessage command;

--- a/libntxm/include/ntxm/fifocommand.h
+++ b/libntxm/include/ntxm/fifocommand.h
@@ -145,6 +145,7 @@ void CommandStopPlay(void);
 void CommandSetDebugStrPtr(char **arm7debugstrs, u16 debugstrsize, u8 n_debugbufs);
 void CommandPlayInst(u8 inst, u8 note, u8 volume, u8 channel);
 void CommandStopInst(u8 channel);
+void CommandStopMidiInst(u8 inst, u8 note, u8 volume, u8 channel);
 void CommandMicOn(void);
 void CommandMicOff(void);
 void CommandSetPatternLoop(bool state);

--- a/libntxm/include/ntxm/fifocommand.h
+++ b/libntxm/include/ntxm/fifocommand.h
@@ -27,6 +27,7 @@ typedef enum {
     UPDATE_POTPOS,
     PLAY_INST,
     STOP_INST,
+    STOP_MIDI_INST,
     NOTIFY_STOP,
     MIC_ON,
     MIC_OFF,
@@ -92,6 +93,13 @@ struct StopInstCommand {
     u8 channel;
 };
 
+struct StopMidiInstCommand {
+    u8 inst;
+    u8 note;
+    u8 volume;
+    u8 channel;
+};
+
 struct PatternLoopCommand {
     bool state;
 };
@@ -116,6 +124,7 @@ typedef struct NTXMFifoMessage {
         UpdatePotPosCommand    updatePotPos;
         PlayInstCommand        playInst;
         StopInstCommand        stopInst;
+        StopMidiInstCommand    stopMidiInst;
         PatternLoopCommand     ptnLoop;
         SetStereoOutputCommand setStereoOutput;
     };

--- a/libntxm/include/ntxm/ntxm7.h
+++ b/libntxm/include/ntxm/ntxm7.h
@@ -62,6 +62,9 @@ class NTXM7
 		//  volume: 0-255
 		// channel: 0-15, 255=auto
 		void playNote(u8 instidx, u8 note=48, u8 volume=255, u8 channel=255);
+
+		// Find a note currently being played by an instument, and stop it.
+		void stopNote(u8 note, u8 volume, u8 channel, u8 instidx);
 		
 		// Play the given sample (and send a notification when done)
 		void playSample(Sample *sample, u8 note, u8 volume, u8 channel);

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -139,7 +139,7 @@ class Player {
 		// Play the given sample (and send a notification when done)
 		void playSample(Sample *sample, u8 note, u8 volume, u8 channel);
 
-		void stopNode(u8 note, u8 volume, u8 channel, u8 instidx);
+		void stopNote(u8 note, u8 volume, u8 channel, u8 instidx);
 
 		// Stop playback on a channel
 		void stopChannel(u8 channel);

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -139,6 +139,8 @@ class Player {
 		// Play the given sample (and send a notification when done)
 		void playSample(Sample *sample, u8 note, u8 volume, u8 channel);
 
+		void stopNode(u8 note, u8 volume, u8 channel, u8 instidx);
+
 		// Stop playback on a channel
 		void stopChannel(u8 channel);
 


### PR DESCRIPTION
Previously, stopping notes relied on stopChannel which requires the channel number be explicitly declared. If the auto channel finding feature was used, this was done by the player state storing the previous auto channel. But, polyphony breaks this because if a second note is played via the auto channel finder then the previous auto channel variable is overwritten before it's stopped.

This adds an alternate pathway that takes the note and instrument and searches all channels for an instance of that note/instrument combo playing, and stops it. This enables polyphony.