### PR TITLE
More accurate instrument column

### DIFF
--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -183,7 +183,6 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 	// Stop possibly active fades
 	state.channel_fade_active[channel] = 0;
 	state.channel_fade_ms[channel] = 0;
-	state.channel_instrument[channel] = instidx;
 
 	if(volume == NO_VOLUME) {
 		state.channel_volume[channel] = MAX_VOLUME * inst->getSampleForNote(note)->getVolume() / 255;
@@ -503,6 +502,11 @@ void Player::playRow(void)
 		u8 effect = song->patterns[state.pattern][channel][state.row].effect;
 		u8 param  = song->patterns[state.pattern][channel][state.row].effect_param;
 		u16 test_delay = (((effect << 8) & 0x0f00) | (param & 0xf0));
+
+		if(inst == NO_INSTRUMENT)
+			inst = state.channel_instrument[channel];
+		else
+			state.channel_instrument[channel] = inst;
 
 		effect = (effect >> 4) & 0xf;
 


### PR DESCRIPTION
- If a note has no instrument value, use the last instrument value.
- If a row has an instrument value but no note, use that instrument for the next note.

This matches the behaviour of other XM trackers.