### PR TITLE
Replace autochannel with channel tags (for Piano Pak / MIDI polyphony)

### DIFF
--- a/libntxm/arm7/source/fifocommand7.cpp
+++ b/libntxm/arm7/source/fifocommand7.cpp
@@ -93,6 +93,14 @@ static void RecvCommandStopInst(StopInstCommand *c) {
     ntxm7->stopChannel(c->channel);
 }
 
+static void RecvCommandPlayNoteAuto(PlayNoteAutoCommand *c) {
+    ntxm7->playNoteAuto(c->inst, c->note, c->volume, c->tag);
+}
+
+static void RecvCommandStopNoteAuto(StopNoteAutoCommand *c) {
+    ntxm7->stopNoteAuto(c->tag);
+}
+
 static void RecvCommandStopMatchingInst(StopMatchingInstCommand *c) {
     ntxm7->stopAllNotes(c->note, c->inst);
 }
@@ -203,6 +211,12 @@ void CommandRecvHandler(int bytes, void *user_data) {
             break;
         case STOP_MATCHING_INST:
             RecvCommandStopMatchingInst(&command.stopMatchingInst);
+            break;
+        case PLAY_NOTE_AUTO:
+            RecvCommandPlayNoteAuto(&command.playNoteAuto);
+            break;
+        case STOP_NOTE_AUTO:
+            RecvCommandStopNoteAuto(&command.stopNoteAuto);
             break;
         case MIC_ON:
             RecvCommandMicOn();

--- a/libntxm/arm7/source/ntxm7.cpp
+++ b/libntxm/arm7/source/ntxm7.cpp
@@ -100,6 +100,16 @@ void NTXM7::stopChannel(u8 channel)
 	player->stopChannel(channel);
 }
 
+void NTXM7::playNoteAuto(u8 instidx, u8 note, u8 volume, u16 tag)
+{
+	player->playNoteAuto(instidx, note, volume, tag);
+}
+
+void NTXM7::stopNoteAuto(u16 tag)
+{
+	player->stopNoteAuto(tag);
+}
+
 void NTXM7::setPatternLoop(bool loopstate)
 {
 	player->setPatternLoop(loopstate);

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -384,7 +384,7 @@ void Player::playTimerHandler(void)
 	}
 
 	// Update active channels
-	for(u8 channel=0; channel<song->n_channels && channel<MAX_CHANNELS; ++channel)
+	for(u8 channel=0; channel<MAX_CHANNELS; ++channel)
 	{
 		if(state.channel_ms_left[channel] > 0)
 		{

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -149,13 +149,14 @@ void Player::stop(void)
 	resetPanning();
 }
 
-// Play the note with the given settings. channel == 255 -> search for free channel
+// Play the note with the given settings.
 void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 {
 	//reset portamento to init
 	state.channel_porta_accumulator[channel] = 0;
 	state.channel_porta_increment[channel] = 0;
 	state.channel_porta_enabled[channel] = false;
+	state.channel_tags[channel] = UNTAGGED;
 	
 	if( (state.playing == true) && (song->channelMuted(channel) == true) )
 		return;
@@ -168,21 +169,6 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 	Sample *smp = inst->getSampleForNote(note);
 	if (smp == 0)
 		return;
-
-	if(channel == 255) // Find a free channel
-	{
-		s8 c = MAX_CHANNELS-1;
-		while( ( state.channel_active[c] == 1) && ( c >= 0 ) )
-			--c;
-
-		if( c < 0 )
-			return;
-		else
-		{
-			channel = c;
-			state.last_autochannel = c;
-		}
-	}
 
 	// Stop possibly active fades
 	state.channel_fade_active[channel] = 0;
@@ -250,11 +236,6 @@ void Player::stopAllNotes(u8 note, u8 instidx)
 // Stop playback on a channel
 void Player::stopChannel(u8 channel)
 {
-	if(channel == 255) // Autochannel
-	{
-		channel = state.last_autochannel;
-	}
-
 	// Stop single sample if it's played on this channel
 	if((state.playing_single_sample == true) && (state.single_sample_channel == channel))
 	{
@@ -270,6 +251,53 @@ void Player::stopChannel(u8 channel)
 		state.channel_fade_active[channel]        = 1;
 		state.channel_fade_ms[channel]            = FADE_OUT_MS;
 		state.channel_fade_target_volume[channel] = 0;
+	}
+	
+	state.channel_tags[channel] = UNTAGGED;
+}
+
+int Player::getChannelForTag(u16 tag)
+{
+	int i;
+	
+	// First look for existing channels using this tag, just in case.
+	for (i = 0; i < MAX_CHANNELS; i++) {
+		if (state.channel_tags[i] == tag) {
+			return i;
+		}
+	}
+	// Look for inactive channels.
+	for (i = MAX_CHANNELS-1; i > 0; i--) {
+		if (state.channel_active[i] == 0) {
+			return i;
+		}
+	}
+	// Look for deprioritized channels.
+	for (i = MAX_CHANNELS-1; i > 0; i--) {
+		if (state.channel_active[i] == 2) {
+			return i;
+		}
+	}
+	// Fail
+	return -1;
+}
+
+void Player::playNoteAuto(u8 instidx, u8 note, u8 volume, u16 tag)
+{
+	int channel = getChannelForTag(tag);
+	if (channel != -1) {
+		playNote(note, volume, channel, instidx);
+		state.channel_tags[channel] = tag;
+	}
+}
+
+void Player::stopNoteAuto(u16 tag)
+{
+	for (int i = 0; i < MAX_CHANNELS; i++) {
+		if (state.channel_tags[i] == tag) {
+			stopChannel(i);
+			return;
+		}
 	}
 }
 
@@ -1031,6 +1059,7 @@ void Player::initState(void)
 	memset(state.channel_vib_accumulator, 0, sizeof(state.channel_vib_accumulator));
 	memset(state.channel_vib_phase_increment, 0, sizeof(state.channel_vib_phase_increment));
 	memset(state.channel_vib_depth, 0, sizeof(state.channel_vib_depth));
+	memset(state.channel_tags, 0xff, sizeof(state.channel_tags));  // fill with UNTAGGED (u16)
 	state.playing_single_sample = false;
 	state.single_sample_ms_remaining = 0;
 	state.single_sample_channel = 0;

--- a/libntxm/arm9/source/fifocommand9.cpp
+++ b/libntxm/arm9/source/fifocommand9.cpp
@@ -218,6 +218,33 @@ void CommandStopMatchingInst(u8 inst, u8 note)
     fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
 }
 
+void CommandPlayNoteAuto(u8 inst, u8 note, u8 volume, u16 tag)
+{
+    NTXMFifoMessage command;
+    command.commandType = PLAY_NOTE_AUTO;
+
+    PlayNoteAutoCommand* c = &command.playNoteAuto;
+
+    c->inst    = inst;
+    c->note    = note;
+    c->volume  = volume;
+    c->tag  = tag;
+
+    fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
+}
+
+void CommandStopNoteAuto(u16 tag)
+{
+    NTXMFifoMessage command;
+    command.commandType = STOP_NOTE_AUTO;
+
+    StopNoteAutoCommand* c = &command.stopNoteAuto;
+
+    c->tag = tag;
+
+    fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
+}
+
 void CommandMicOn(void)
 {
     NTXMFifoMessage command;

--- a/libntxm/include/ntxm/fifocommand.h
+++ b/libntxm/include/ntxm/fifocommand.h
@@ -28,6 +28,8 @@ typedef enum {
     PLAY_INST,
     STOP_INST,
     STOP_MATCHING_INST,
+    PLAY_NOTE_AUTO,
+    STOP_NOTE_AUTO,
     NOTIFY_STOP,
     MIC_ON,
     MIC_OFF,
@@ -100,6 +102,17 @@ struct StopMatchingInstCommand {
     u8 note;
 };
 
+struct PlayNoteAutoCommand {
+    u8 inst;
+    u8 note;
+    u8 volume;
+    u16 tag;
+};
+
+struct StopNoteAutoCommand {
+    u16 tag;
+};
+
 struct PatternLoopCommand {
     bool state;
 };
@@ -127,6 +140,8 @@ typedef struct NTXMFifoMessage {
         PlayInstCommand        playInst;
         StopInstCommand        stopInst;
         StopMatchingInstCommand    stopMatchingInst;
+        PlayNoteAutoCommand    playNoteAuto;
+        StopNoteAutoCommand    stopNoteAuto;
         PatternLoopCommand     ptnLoop;
         SetStereoOutputCommand setStereoOutput;
     };
@@ -148,6 +163,8 @@ void CommandSetDebugStrPtr(char **arm7debugstrs, u16 debugstrsize, u8 n_debugbuf
 void CommandPlayInst(u8 inst, u8 note, u8 volume, u8 channel);
 void CommandStopInst(u8 channel);
 void CommandStopMatchingInst(u8 inst, u8 note);
+void CommandPlayNoteAuto(u8 inst, u8 note, u8 volume, u16 tag);
+void CommandStopNoteAuto(u16 tag);
 void CommandMicOn(void);
 void CommandMicOff(void);
 void CommandSetPatternLoop(bool state);

--- a/libntxm/include/ntxm/ntxm7.h
+++ b/libntxm/include/ntxm/ntxm7.h
@@ -60,8 +60,8 @@ class NTXM7
 		// instidx: index of the instrument
 		//    note: 48 corresponds to c-4
 		//  volume: 0-255
-		// channel: 0-15, 255=auto
-		void playNote(u8 instidx, u8 note=48, u8 volume=255, u8 channel=255);
+		// channel: 0-15
+		void playNote(u8 instidx, u8 note, u8 volume, u8 channel);
 
 		// Find all matching notes currently being played by an instument, and stop it.
 		void stopAllNotes(u8 note, u8 instidx);
@@ -71,6 +71,10 @@ class NTXM7
 		
 		// Stop playback on a channel
 		void stopChannel(u8 channel);
+		
+		void playNoteAuto(u8 instidx, u8 note, u8 volume, u16 tag);
+		
+		void stopNoteAuto(u16 tag);
 		
 		// Set a pattern to looping
 		void setPatternLoop(bool loopstate);

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -46,6 +46,8 @@
 
 #define DELAY_CMD 0x0ed0
 
+#define UNTAGGED 0xffff  // Indicates that this channel is not playing a note issued via MIDI or Piano Pak, etc.
+
 typedef struct
 {
 	u16 row;							// Current row
@@ -79,6 +81,8 @@ typedef struct
 	u8 channel_vib_accumulator[MAX_CHANNELS];
 	u8 channel_vib_phase_increment[MAX_CHANNELS];
 	u16 channel_vib_depth[MAX_CHANNELS];
+	u16 channel_tags[MAX_CHANNELS];  // For MIDI and Piano Pak, need to remember which channel holds which
+	                                 // user-played note so we can turn them off when the key is released.
 	
 	bool waitrow;							// Wait until the end of the last tick before muting instruments
 	bool patternloop;						// Loop the current pattern
@@ -86,8 +90,6 @@ typedef struct
 	bool playing_single_sample;
 	u32 single_sample_ms_remaining;
 	u8 single_sample_channel;
-
-	u8 last_autochannel;				// Last channel used for playing an inst with channel==255
 } PlayerState;
 
 typedef struct {
@@ -145,6 +147,13 @@ class Player {
 		// Stop playback on a channel
 		void stopChannel(u8 channel);
 
+		// Play a user-input note, finding a freely available channel.
+		// tag usually equals note, but lacks octave for Piano Pak inputs, and includes instrument for MIDI inputs.
+		void playNoteAuto(u8 instidx, u8 note, u8 volume, u16 tag);
+		
+		// Stop a user-input note on whichever channel it's playing.
+		void stopNoteAuto(u16 tag);
+
 		//
 		// Callbacks
 		//
@@ -168,6 +177,8 @@ class Player {
 		void handleEffects(void); // Row Effect handler
 		void handleTickEffects(void); // Tick Effect handler
 		void finishEffects(void); // Clean up after the effects
+
+		int getChannelForTag(u16 tag);
 
 		void initState(void);
 		void initEffState(void);


### PR DESCRIPTION
This PR removes the concept of channel 255 as the 'autochannel', and replaces it with two new commands `PlayNoteAuto` and `StopNoteAuto`. The former takes a tag which is also used with the latter, to stop the note without needing to know which channel the note is playing on.

This allows for proper polyphony with MIDI and the Easy Piano peripheral.

Some out of bounds accesses have also been fixed along the way, as `Player::playNote` would attempt to use `channel` to write to some arrays even while the value was still 255.