### PR TITLE
Track piano note position in play timer

### DIFF
--- a/libntxm/arm7/source/fifocommand7.cpp
+++ b/libntxm/arm7/source/fifocommand7.cpp
@@ -152,6 +152,25 @@ void CommandUpdatePotPos(u16 potpos)
     fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
 }
 
+void CommandUpdateCursorPos(u32 cursorpos)
+{
+    NTXMFifoMessage command;
+    command.commandType = UPDATE_CURSORPOS;
+
+    UpdateCursorPosCommand *c = &command.updateCursorPos;
+    c->cursorpos = cursorpos;
+
+    fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
+}
+
+void CommandStopCursor(void)
+{
+    NTXMFifoMessage command;
+    command.commandType = STOP_CURSOR;
+
+    fifoSendDatamsg(FIFO_NTXM, sizeof(command), (u8*)&command);
+}
+
 void CommandNotifyStop(void)
 {
     NTXMFifoMessage command;

--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -149,6 +149,99 @@ void Player::stop(void)
 	resetPanning();
 }
 
+void Player::calcCursorPos(u32 n_ticks)
+{
+	if (!state.playing_piano_sample)
+		return;
+
+	const u8 looptype = state.piano_sample_looptype;
+
+	// promoted and shifted up for fixed point calcs, 
+	// for accuracy. only shift down when passing to sampledisp
+	const u64 loopstart = (u64)state.piano_sample_loopstart << 32;
+	const u64 looplen = (u64)state.piano_sample_looplen << 32;
+	const u64 nsamps = (u64)state.piano_sample_nsamps_total << 32;
+	const u64 loopend = loopstart + looplen;
+	
+	bool& looprev = state.piano_sample_loopreverse;
+	u64& playpos = state.piano_sample_nsamps_position; // alias the name for cleanliness
+
+	if (n_ticks == 0) return;
+	
+	const u64 step = ((u64)state.piano_sample_playfreq << 32) / (1000 / (u64)n_ticks); // timer
+
+	if (looprev) {
+		if (step > playpos) {
+			playpos = loopstart + step - playpos;
+			looprev = false;
+		} else
+			playpos -= step;
+	} else
+		playpos += step;
+
+	if (looptype == FORWARD_LOOP && playpos >= loopend)
+		playpos = loopstart + playpos - loopend;
+	else if (looptype == PING_PONG_LOOP) {
+		if (looprev && playpos <= loopstart) {
+			// 2*playback pos, as the second one is used to calculate
+			// the error that needs to be corrected
+			playpos = 2 * loopstart - playpos;
+			looprev = false;
+		}
+		else if (!looprev && playpos >= loopend) {
+			// same here
+			playpos = 2 * loopend - playpos;
+			looprev = true;
+		}
+	}
+	else if (looptype == NO_LOOP && playpos >= nsamps) {
+		CommandStopCursor();
+		return;
+	}
+
+	if (looptype != NO_LOOP && looplen <= step && playpos > loopstart)
+		if (looptype == PING_PONG_LOOP && looprev)
+			playpos = loopend - (step % looplen);
+		else
+			playpos = loopstart + (step % looplen);
+
+	CommandUpdateCursorPos(playpos >> 32); // sampledisplay doesn't need the precision 
+}
+
+void Player::cursorStart(u8 note, u8 instidx)
+{
+	Instrument *inst = song->getInstrument(instidx);
+	if (inst==0) return;
+
+	Sample *smp = inst->getSampleForNote(note);
+	if (smp==0) return;
+	sample_lastms = getTicks();
+	
+	state.piano_sample_playfreq = smp->getPlaybackFreq(note);
+	state.piano_sample_loopreverse = false;
+	state.piano_sample_nsamps_position = 0;
+	state.piano_sample_nsamps_total = smp->getNSamples();
+	state.piano_sample_looptype = smp->getLoop();
+	state.piano_sample_looplen = smp->getLoopLength(); // will be 0 for non loop
+	state.piano_sample_loopstart = smp->getLoopStart();  //
+
+	state.playing_piano_sample = true;
+}
+
+void Player::cursorStop(void)
+{
+	// no need to clear most of these as they will be
+	// reset in cursorStart if needed. still, may as well...
+	state.playing_piano_sample = false;
+	state.piano_sample_loopreverse = false;
+	state.piano_sample_nsamps_position = 0;
+	state.piano_sample_nsamps_total = 0;
+	state.piano_sample_playfreq = 0;
+	state.piano_sample_loopstart = 0;
+	state.piano_sample_looplen = 0;
+	state.piano_sample_looptype = NO_LOOP;
+}
+
 // Play the note with the given settings. channel == 255 -> search for free channel
 void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 {
@@ -167,6 +260,8 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 
 	if(channel == 255) // Find a free channel
 	{
+		cursorStart(note, instidx); // after pr11 merge: move this to playNoteAuto
+
 		s8 c = MAX_CHANNELS-1;
 		while( ( state.channel_active[c] == 1) && ( c >= 0 ) )
 			--c;
@@ -179,6 +274,7 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 			state.last_autochannel = c;
 		}
 	}
+
 
 	// Stop possibly active fades
 	state.channel_fade_active[channel] = 0;
@@ -248,6 +344,7 @@ void Player::stopChannel(u8 channel)
 {
 	if(channel == 255) // Autochannel
 	{
+		cursorStop();
 		channel = state.last_autochannel;
 	}
 
@@ -269,8 +366,18 @@ void Player::stopChannel(u8 channel)
 	}
 }
 
+
 void Player::playTimerHandler(void)
 {
+	// cursor calculations, may as well reuse the same timer
+	if (state.playing_piano_sample)
+	{
+		u32 sample_passed_time = getTicks() - sample_lastms;
+		sample_lastms = getTicks();
+
+		calcCursorPos(sample_passed_time);
+	}	
+
 	if(ntxm_recording && !state.playing)
 		return;
 
@@ -1030,6 +1137,14 @@ void Player::initState(void)
 	state.playing_single_sample = false;
 	state.single_sample_ms_remaining = 0;
 	state.single_sample_channel = 0;
+	state.playing_piano_sample = false;
+	state.piano_sample_loopreverse = false;
+	state.piano_sample_nsamps_position = 0;
+	state.piano_sample_nsamps_total = 0;
+	state.piano_sample_playfreq = 0;
+	state.piano_sample_loopstart = 0;
+	state.piano_sample_looplen = 0;
+	state.piano_sample_looptype = NO_LOOP;
 }
 
 void Player::initEffState(void)

--- a/libntxm/arm9/source/fifocommand9.cpp
+++ b/libntxm/arm9/source/fifocommand9.cpp
@@ -13,6 +13,8 @@ void (*onUpdateRow)(u16 row) = 0;
 void (*onStop)(void) = 0;
 void (*onPlaySampleFinished)(void) = 0;
 void (*onPotPosChange)(u16 potpos) = 0;
+void (*onCursorPosChange)(u32 samplepos) = 0;
+void (*onStopCursor)(void) = 0;
 
 void RegisterRowCallback(void (*onUpdateRow_)(u16))
 {
@@ -34,6 +36,16 @@ void RegisterPotPosChangeCallback(void (*onPotPosChange_)(u16))
     onPotPosChange = onPotPosChange_;
 }
 
+void RegisterCursorPosChangeCallback(void (*onCursorPosChange_)(u32))
+{
+    onCursorPosChange = onCursorPosChange_;
+}
+
+void RegisterStopCursorCallback(void (*onStopCursor_)(void))
+{
+    onStopCursor = onStopCursor_;
+}
+
 void RecvCommandUpdateRow(UpdateRowCommand *c)
 {
     if(onUpdateRow)
@@ -45,6 +57,19 @@ void RecvCommandUpdatePotPos(UpdatePotPosCommand *c)
     if(onPotPosChange)
         onPotPosChange(c->potpos);
 }
+
+void RecvCommandUpdateCursorPos(UpdateCursorPosCommand *c)
+{
+    if(onCursorPosChange)
+        onCursorPosChange(c->cursorpos);
+}
+
+void RecvComandStopCursor(void)
+{
+    if(onStopCursor)
+        onStopCursor();
+}
+
 
 void RecvCommandNotifyStop(void)
 {
@@ -68,15 +93,18 @@ void CommandRecvHandler(int bytes, void *user_data) {
             ntxm_dprintf(msg.dbgOut.msg);
             break;
 #endif
-
         case UPDATE_ROW:
             RecvCommandUpdateRow(&msg.updateRow);
             break;
-
         case UPDATE_POTPOS:
             RecvCommandUpdatePotPos(&msg.updatePotPos);
             break;
-
+        case UPDATE_CURSORPOS:
+            RecvCommandUpdateCursorPos(&msg.updateCursorPos);
+            break;
+        case STOP_CURSOR:
+            RecvComandStopCursor();
+            break;
         case NOTIFY_STOP:
             RecvCommandNotifyStop();
             break;

--- a/libntxm/common/source/instrument.cpp
+++ b/libntxm/common/source/instrument.cpp
@@ -218,6 +218,7 @@ u32 Instrument::calcPlayLength(u8 note) {
 	return samples[note_samples[note]]->calcPlayLength(note);
 }
 
+
 #ifdef ARM9
 
 const char *Instrument::getName(void) {

--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -212,7 +212,7 @@ void Sample::play(u8 note, u8 volume_ , u8 channel)
 		return;
 	}
 	*/
-
+	
 	u32 loop_bit;
 	if( ( ( loop == FORWARD_LOOP ) || (loop == PING_PONG_LOOP) ) && (loop_length > 0) )
 		loop_bit = SOUND_REPEAT;
@@ -288,7 +288,7 @@ void Sample::bendNoteDirect(s16 fine_step, u8 channel)
 
 u32 Sample::calcPlayLength(u8 note)
 {
-	u32 samples_per_second = LOOKUP_FREQ(48+note+rel_note,finetune);
+	u32 samples_per_second = getPlaybackFreq(note);
 	if (samples_per_second == 0) return 0;
 	return n_samples * 1000 / samples_per_second;
 }
@@ -321,6 +321,10 @@ u32 Sample::getSize(void)
 u32 Sample::getNSamples(void)
 {
 	return n_samples;
+}
+
+u32 Sample::getPlaybackFreq(u8 note_) {
+    return LOOKUP_FREQ(48+note_+rel_note,finetune);
 }
 
 void *Sample::getData(void)

--- a/libntxm/include/ntxm/fifocommand.h
+++ b/libntxm/include/ntxm/fifocommand.h
@@ -25,6 +25,8 @@ typedef enum {
     DBG_OUT,
     UPDATE_ROW,
     UPDATE_POTPOS,
+    UPDATE_CURSORPOS,
+    STOP_CURSOR,
     PLAY_INST,
     STOP_INST,
     STOP_MATCHING_INST,
@@ -84,6 +86,13 @@ struct UpdatePotPosCommand {
     u16 potpos;
 };
 
+struct UpdateCursorPosCommand {
+    u32 cursorpos;
+};
+
+struct StopCursorCommand {
+};
+
 struct PlayInstCommand {
     u8 inst;
     u8 note;
@@ -124,6 +133,8 @@ typedef struct NTXMFifoMessage {
 #endif
         UpdateRowCommand       updateRow;
         UpdatePotPosCommand    updatePotPos;
+        UpdateCursorPosCommand updateCursorPos;
+        StopCursorCommand      stopCursor;
         PlayInstCommand        playInst;
         StopInstCommand        stopInst;
         StopMatchingInstCommand    stopMatchingInst;
@@ -157,6 +168,8 @@ void RegisterRowCallback(void (*onUpdateRow_)(u16));
 void RegisterStopCallback(void (*onStop_)(void));
 void RegisterPlaySampleFinishedCallback(void (*onPlaySampleFinished_)(void));
 void RegisterPotPosChangeCallback(void (*onPotPosChange_)(u16));
+void RegisterCursorPosChangeCallback(void (*onCursorPosChange_)(u32));
+void RegisterStopCursorCallback(void (*onStopCursor_)(void));
 #endif
 
 #if defined(ARM7)
@@ -167,6 +180,8 @@ void CommandDbgOut(const char *formatstr, ...); // Print text from the ARM7, syn
 #endif
 void CommandUpdateRow(u16 row);
 void CommandUpdatePotPos(u16 potpos);
+void CommandUpdateCursorPos(u32 cursorpos);
+void CommandStopCursor(void);
 void CommandNotifyStop(void);
 void CommandSampleFinish(void);
 #endif

--- a/libntxm/include/ntxm/instrument.h
+++ b/libntxm/include/ntxm/instrument.h
@@ -76,7 +76,6 @@ class Instrument
 		
 		// Calculate how long in ms the instrument will play note given note
 		u32 calcPlayLength(u8 note);
-		
 		const char *getName(void);
 		void setName(const char *_name);
 	

--- a/libntxm/include/ntxm/player.h
+++ b/libntxm/include/ntxm/player.h
@@ -87,6 +87,17 @@ typedef struct
 	u32 single_sample_ms_remaining;
 	u8 single_sample_channel;
 
+	// pr11: maybe the tag for the note whose cursor is playing should be stored here
+	// (allows multiple cursors)
+	bool playing_piano_sample;
+	bool piano_sample_loopreverse;
+	u64 piano_sample_nsamps_position;		// 32.32 for accuracy. use nsamples for sampleToPixel--we dont need ms
+	u32 piano_sample_nsamps_total;
+	u32 piano_sample_playfreq;
+	u32 piano_sample_loopstart;
+	u32 piano_sample_looplen;
+	u8 piano_sample_looptype;
+
 	u8 last_autochannel;				// Last channel used for playing an inst with channel==255
 } PlayerState;
 
@@ -133,6 +144,8 @@ class Player {
 
 		void stop(void);
 
+		void cursorStart(u8 note, u8 instidx);
+		void cursorStop(void);
 		// Play the note with the given settings. channel == 255 -> search for free channel
 		void playNote(u8 note, u8 volume, u8 channel, u8 instidx);
 
@@ -179,6 +192,7 @@ class Player {
 
 		bool calcNextPos(u16 *nextrow, u8 *nextpotpos); // Calculate next row and pot position
 
+		void calcCursorPos(u32 n_ticks); // for sample display cursor. Send a fifo message with n_samples progress
 		Song *song;
 		PlayerState state;
 		EffectState effstate;
@@ -189,6 +203,7 @@ class Player {
 		void (*onSampleFinish)();
 
 		u32 lastms; // For timer
+		u32 sample_lastms; 
 };
 
 #endif

--- a/libntxm/include/ntxm/sample.h
+++ b/libntxm/include/ntxm/sample.h
@@ -62,7 +62,6 @@ class Sample
 		~Sample();
 
 		void saveAsWav(char *filename);
-
 		void play(u8 note, u8 volume_, u8 channel  /* effects here */);
 		void bendNote(u8 note, u8 basenote, s16 _finetune, u8 channel);
 		void bendNoteDirect(s16 fine_step, u8 channel);
@@ -76,7 +75,7 @@ class Sample
 
 		u32 getSize(void); // Get the size in bytes
 		u32 getNSamples(void); // Get the numer of (PCM) samples
-
+		u32 getPlaybackFreq(u8 note_);
 		void *getData(void);
 
 		u8 getLoop(void); // 0: no loop, 1: loop, 2: ping pong loop
@@ -103,7 +102,7 @@ class Sample
 
 		// Deletes the part between start sample and end sample
 		void delPart(u32 startsample, u32 endsample);
-
+		void delAll(void);
 		void fadeIn(u32 startsample, u32 endsample);
 		void fadeOut(u32 startsample, u32 endsample);
 		bool reverse(u32 startsample, u32 endsample);
@@ -119,7 +118,7 @@ class Sample
 		void calcRelnoteAndFinetune(u32 freq);
 		u16 findClosestFreq(u32 freq);
 		bool convertStereoToMono(void);
-
+		
 		void fade(u32 startsample, u32 endsample, bool in);
 
 		bool setupPingPongLoop(void);
@@ -146,6 +145,6 @@ class Sample
 
 		Wav wav;
 		// Other formats may follow
-};
+	};
 
 #endif


### PR DESCRIPTION
Uses the existing play timer to calculate the position of the currently playing piano sample, if any, and communicate it with the sample display via a fifo message (such that it remains accurate in slowdowns).

More elaboration is done in review comments and in the main PR 

edit - also, this would need slight alterations when the easy piano PR is done/merged, however they are small and I have left comments detailing them