### PR TITLE
Fix player playing null samples edge case and add delAll to sample.h

### DIFF
--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -165,6 +165,10 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 	if(inst == 0)
 		return;
 
+	Sample *smp = inst->getSampleForNote(note);
+	if (smp == 0)
+		return;
+
 	if(channel == 255) // Find a free channel
 	{
 		s8 c = MAX_CHANNELS-1;
@@ -186,13 +190,13 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 	state.channel_instrument[channel] = instidx;
 	
 	if(volume == NO_VOLUME) {
-		state.channel_volume[channel] = MAX_VOLUME * inst->getSampleForNote(note)->getVolume() / 255;
+		state.channel_volume[channel] = MAX_VOLUME * smp->getVolume() / 255;
 	} else {
-		state.channel_volume[channel] = volume * inst->getSampleForNote(note)->getVolume() / 255;
+		state.channel_volume[channel] = volume * smp->getVolume() / 255;
 	}
-	state.channel_prev_sample_vol[channel] = inst->getSampleForNote(note)->getVolume(); //Store for later channel volume updates
+	state.channel_prev_sample_vol[channel] = smp->getVolume(); //Store for later channel volume updates
 
-	if(inst->getSampleForNote(note)->getLoop() != 0) {
+	if(smp->getLoop() != 0) {
 		state.channel_loop[channel] = true;
 		state.channel_ms_left[channel] = 0;
 	} else {
@@ -206,8 +210,8 @@ void Player::playNote(u8 note, u8 volume, u8 channel, u8 instidx)
 	state.channel_active[channel] = 1;
 
 	//xm standard is to reset effect panning each note
-	u8 pan = inst->getSampleForNote(note)->getBasePanning();
-	inst->getSampleForNote(note)->setPanning(pan);
+	u8 pan = smp->getBasePanning();
+	smp->setPanning(pan);
 	
 	inst->play(note, volume, channel);
 }

--- a/libntxm/common/source/instrument.cpp
+++ b/libntxm/common/source/instrument.cpp
@@ -99,6 +99,7 @@ void Instrument::addSample(Sample *sample)
 
 void Instrument::setSample(u8 idx, Sample *sample)
 {
+	
 	// Delete the sample if it already exists
 	if( (idx < n_samples) && (samples[idx] != 0) )
 		delete samples[idx];
@@ -130,6 +131,8 @@ Sample *Instrument::getSample(u8 idx)
 }
 
 Sample *Instrument::getSampleForNote(u8 _note) {
+	if(note_samples[_note] >= n_samples) return NULL;
+
 	return samples[note_samples[_note]];
 }
 

--- a/libntxm/include/ntxm/sample.h
+++ b/libntxm/include/ntxm/sample.h
@@ -103,7 +103,7 @@ class Sample
 
 		// Deletes the part between start sample and end sample
 		void delPart(u32 startsample, u32 endsample);
-
+		void delAll(void);
 		void fadeIn(u32 startsample, u32 endsample);
 		void fadeOut(u32 startsample, u32 endsample);
 		bool reverse(u32 startsample, u32 endsample);


### PR DESCRIPTION
this has been present in older versions too and would lead to strange behaviour if mapping a key to a null sample then playing that after playing a non-null one