### PR TITLE
Fix bad memory access in Player.cpp causing massive slowdowns with instrument gaps

### DIFF
--- a/libntxm/arm7/source/player.cpp
+++ b/libntxm/arm7/source/player.cpp
@@ -1060,6 +1060,7 @@ void Player::initDefaultPanning(void)
 	for ( u8 i = 0; i < instcount; i++)
 	{
 		inst = song->instruments[i];
+		if (inst == 0) continue;
 		smpidx = inst->getSamples();
 		for (u16 j = 0; j < smpidx; j++)
 		{
@@ -1078,6 +1079,7 @@ void Player::resetPanning(void)
 	for ( u8 i = 0; i < instcount; i++)
 	{
 		inst = song->instruments[i];
+		if (inst == 0) continue;
 		smpidx = inst->getSamples();
 		for (u16 j = 0; j < smpidx; j++)
 		{


### PR DESCRIPTION
"smpidx" is read as 65535 for null instruments

This might also fix https://github.com/NitrousTracker/nitroustracker/issues/141 because sometimes when I deliberately create huge instrument gaps it waits for ages then plays extremely fast