### PR TITLE
getMaxAmplitude function

### DIFF
--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -622,35 +622,41 @@ bool Sample::reverse(u32 startsample, u32 endsample)
 	return true;
 }
 
-void Sample::autoNormalize(u32 startsample, u32 endsample)
+u32 Sample::getDynamicRange(void)
+{
+	if (is_16_bit == true)
+		return 32767;
+	else
+		return 127;
+}
+
+u32 Sample::getMaxAmplitude(u32 startsample, u32 endsample)
 {
 	void *data = getData();
 	u32 max_smp = 0;
-	u32 dr = 0;
+	u32 dr = getDynamicRange();
+
 	if(is_16_bit == true)
 	{
-		dr = 32767;
 		s16 *sounddata = (s16*)(data);
 
 		for(u32 i=startsample;i<endsample;++i) {
 			u32 ampl = abs((s32)sounddata[i]);
 			max_smp = MAX(ampl, max_smp);
-			if (ampl == 32767) break;
+			if (ampl == dr) return dr;
 		}
 
 	} else {
-		dr = 128;
 		s8 *sounddata = (s8*)(data);
 
 		for(u32 i=startsample;i<endsample;++i) {
 			u32 ampl = abs((s32)sounddata[i]);
 			max_smp = MAX(ampl, max_smp);
-			if (ampl == 127) break;
+			if (ampl == dr) return dr;
 		}
 	}
-	u16 factor = (dr << 16) / ((max_smp << 16) / 100);
-	factor = ntxm_clamp(factor, 100, 2000);
-	normalize(factor, startsample, endsample);
+
+	return max_smp;
 }
 
 void Sample::normalize(u16 percent, u32 startsample, u32 endsample)

--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -625,16 +625,16 @@ bool Sample::reverse(u32 startsample, u32 endsample)
 u32 Sample::getDynamicRange(void)
 {
 	if (is_16_bit == true)
-		return 32767;
+		return 0xffff;
 	else
-		return 127;
+		return 0xff;
 }
 
 u32 Sample::getMaxAmplitude(u32 startsample, u32 endsample)
 {
 	void *data = getData();
 	u32 max_smp = 0;
-	u32 dr = getDynamicRange();
+	u32 dr = getDynamicRange() / 2;
 
 	if(is_16_bit == true)
 	{

--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -622,6 +622,36 @@ bool Sample::reverse(u32 startsample, u32 endsample)
 	return true;
 }
 
+void Sample::autoNormalize(u32 startsample, u32 endsample)
+{
+	void *data = getData();
+	u32 max_smp = 0;
+	u32 dr = 0;
+	if(is_16_bit == true)
+	{
+		dr = 32767;
+		s16 *sounddata = (s16*)(data);
+
+		for(u32 i=startsample;i<endsample;++i) {
+			u32 ampl = abs((s32)sounddata[i]);
+			max_smp = MAX(ampl, max_smp);
+			if (ampl == 32767) break;
+		}
+
+	} else {
+		dr = 128;
+		s8 *sounddata = (s8*)(data);
+
+		for(u32 i=startsample;i<endsample;++i) {
+			u32 ampl = abs((s32)sounddata[i]);
+			max_smp = MAX(ampl, max_smp);
+			if (ampl == 127) break;
+		}
+	}
+	u16 factor = (dr << 16) / ((max_smp << 16) / 100);
+	factor = ntxm_clamp(factor, 100, 2000);
+	normalize(factor, startsample, endsample);
+}
 
 void Sample::normalize(u16 percent, u32 startsample, u32 endsample)
 {

--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -625,9 +625,9 @@ bool Sample::reverse(u32 startsample, u32 endsample)
 u32 Sample::getDynamicRange(void)
 {
 	if (is_16_bit == true)
-		return 0xffff;
+		return 0xffff + 1;
 	else
-		return 0xff;
+		return 0xff + 1;
 }
 
 u32 Sample::getMaxAmplitude(u32 startsample, u32 endsample)

--- a/libntxm/include/ntxm/sample.h
+++ b/libntxm/include/ntxm/sample.h
@@ -108,6 +108,7 @@ class Sample
 		void fadeOut(u32 startsample, u32 endsample);
 		bool reverse(u32 startsample, u32 endsample);
 		void normalize(u16 percent, u32 startsample, u32 endsample);
+		void autoNormalize(u32 startsample, u32 endsample);
 
 		// Draws a line into the sample
 		void drawLine(int x1, int y1, int x2, int y2);

--- a/libntxm/include/ntxm/sample.h
+++ b/libntxm/include/ntxm/sample.h
@@ -78,7 +78,9 @@ class Sample
 		u32 getNSamples(void); // Get the numer of (PCM) samples
 
 		void *getData(void);
-
+		u32 getMaxAmplitude(u32 startsample, u32 endsample);
+		u32 getDynamicRange(void);
+		
 		u8 getLoop(void); // 0: no loop, 1: loop, 2: ping pong loop
 		bool setLoop(u8 loop_); // Set loop type. Can fail due to memory constraints
 		bool is16bit(void);
@@ -108,7 +110,7 @@ class Sample
 		void fadeOut(u32 startsample, u32 endsample);
 		bool reverse(u32 startsample, u32 endsample);
 		void normalize(u16 percent, u32 startsample, u32 endsample);
-		void autoNormalize(u32 startsample, u32 endsample);
+		
 
 		// Draws a line into the sample
 		void drawLine(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
Finds the peak of the (selected) audio data then adjusts amplitude based on the ratio between that and the max sample amplitude for the sound format. Also calculations are done leftshifted by 16 as the accuracy is necessary for 8 bit samples