### PR TITLE
Clamp loop_start/loop_length in delPart to ensure setupPingPingLoop doesn't occasionally read/write past end of sample buffer

### DIFF
--- a/libntxm/common/source/sample.cpp
+++ b/libntxm/common/source/sample.cpp
@@ -567,6 +567,9 @@ void Sample::delPart(u32 startsample, u32 endsample)
 		}
 	}
 
+	loop_start = ntxm_clamp(loop_start, 0, size - 1);
+	loop_length = ntxm_clamp(loop_length, 0, size - loop_start - 1);
+	
 	setLoopStartAndLength(getLoopStart(), getLoopLength());
 	onSampleDataChanged();
 }


### PR DESCRIPTION
Rare edge case I found with asie's PC port and then confirmed manually in the NDS version.
Occasionally when deleting parts of audio data with a ping-pong looping sample, loop_start / loop_length can exceed the end of the sample by a couple of bytes (please do confirm in case I'm incorrect though). Adding these seemed to resolve the issue (there is still a tiny buffer overread in `setupPingPongLoop`, but it's unrelated and presumably benign).