### PR TITLE
Fix null pointer dereference in calcPlayLength for blank instruments

### DIFF
--- a/libntxm/common/source/instrument.cpp
+++ b/libntxm/common/source/instrument.cpp
@@ -218,7 +218,10 @@ bool Instrument::getVolEnvEnabled(void)
 
 // Calculate how long in ms the instrument will play note given note
 u32 Instrument::calcPlayLength(u8 note) {
-	return samples[note_samples[note]]->calcPlayLength(note);
+	if (samples == NULL)
+		return 0;
+	else 
+		return samples[note_samples[note]]->calcPlayLength(note);
 }
 
 #ifdef ARM9


### PR DESCRIPTION
This is really rare, and I don't think it's possible to do this within NT, however when I loaded some demoscene XM file in NitrousTracker, this caused a segmentation fault because the song used a "dummy" instrument.